### PR TITLE
Add support for YANG multiline string literals

### DIFF
--- a/yang-mode.el
+++ b/yang-mode.el
@@ -179,6 +179,9 @@
 (c-lang-defconst c-modifier-kwds
   yang '())
 
+(c-lang-defconst c-multiline-string-start-char
+  yang t)
+
 (c-lang-defconst c-label-kwds
   yang '())
 


### PR DESCRIPTION
YANG string literals are multiline. cc-mode requires we explicitly tell it this.